### PR TITLE
Add policy entries

### DIFF
--- a/policy/testMapper.paf
+++ b/policy/testMapper.paf
@@ -560,7 +560,7 @@ datasets: {
     }
     IngestIndexedReferenceTask_config: {
         template:      "config/IngestIndexedReferenceTask.py"
-        python:        "lsst.pipe.tasks.htmIndexEngine.IngestIndexedReferenceConfig"
+        python:        "lsst.pipe.tasks.indexReferenceTask.IngestIndexedReferenceConfig"
         persistable:   "Config"
         storage:       "ConfigStorage"
     }

--- a/policy/testMapper.paf
+++ b/policy/testMapper.paf
@@ -558,7 +558,26 @@ datasets: {
         tables:        raw
         tables:        raw_skyTile
     }
-
+    IngestIndexedReferenceTask_config: {
+        template:      "config/IngestIndexedReferenceTask.py"
+        python:        "lsst.pipe.tasks.htmIndexEngine.IngestIndexedReferenceConfig"
+        persistable:   "Config"
+        storage:       "ConfigStorage"
+    }
+    cal_ref_cat: {
+        persistable: SourceCatalog
+        python: lsst.afw.table.SourceCatalog
+        storage: FitsCatalogStorage
+        table: ignored
+        template: photo_astro_ref/%(pixel_id)s.fits
+    }
+    other_photo_astro_ref: {
+        persistable: SourceCatalog
+        python: lsst.afw.table.SourceCatalog
+        storage: FitsCatalogStorage
+        table: ignored
+        template: outher_photo_astro_ref/%(pixel_id)s.fits
+    }
     refcat: {
         template:      "refcat.fits"
         python:        "lsst.afw.table.SimpleCatalog"

--- a/tests/map.py
+++ b/tests/map.py
@@ -67,7 +67,7 @@ class TestMapperTestCase(unittest.TestCase):
 
     def testKeys(self):
         self.assertEqual(set(self.mapper.keys()),
-                set(['filter', 'patch', 'skyTile', 'tract', 'visit']))
+                set(['filter', 'patch', 'skyTile', 'tract', 'visit', 'pixel_id']))
 
     def testGetDatasetTypes(self):
         someKeys = set(['raw', 'processCcd_config', 'processCcd_metadata'])


### PR DESCRIPTION
Add the policy entries necessary for DM-1579.  This leads to a minor
needed change in one of the unit tests.

N.B. I did not update the yaml file since I didn't know what to do
with it, and it isn't used in any tests.