### PR TITLE
Remove IngestIndexedReferenceTask_config

### DIFF
--- a/policy/testMapper.paf
+++ b/policy/testMapper.paf
@@ -582,12 +582,6 @@ datasets: {
         tables:        raw
         tables:        raw_skyTile
     }
-    IngestIndexedReferenceTask_config: {
-        template:      "config/IngestIndexedReferenceTask.py"
-        python:        "lsst.meas.algorithms.IngestIndexedReferenceConfig"
-        persistable:   "Config"
-        storage:       "ConfigStorage"
-    }
     cal_ref_cat: {
         persistable: SourceCatalog
         python: lsst.afw.table.SourceCatalog


### PR DESCRIPTION
Remove IngestIndexedReferenceTask_config from testMapper.paf
in order to use the standard version in daf_butlerUtils