### PR TITLE
DM-13577: Add FGCM datasets to obs_base for persistence

### DIFF
--- a/tests/test_obs_test.py
+++ b/tests/test_obs_test.py
@@ -76,7 +76,8 @@ class TestObsTest(lsst.obs.base.tests.ObsTests, lsst.utils.tests.TestCase):
                               )
 
         path_to_raw = os.path.join(data_dir, "raw", "raw_v1_fg.fits.gz")
-        keys = set(('filter', 'name', 'patch', 'tract', 'visit', 'pixel_id', 'subfilter', 'description'))
+        keys = set(('filter', 'name', 'patch', 'tract', 'visit', 'pixel_id', 'subfilter', 'description',
+                    'fgcmcycle'))
         query_format = ["visit", "filter"]
         queryMetadata = (({'visit': 1}, [(1, 'g')]),
                          ({'visit': 2}, [(2, 'g')]),


### PR DESCRIPTION
This introduces a new key, 'fgcmcycle', which is used in FGCM.