### PR TITLE
DM-13163: Refactor ap_pipe to use CmdLineTask primitives

### DIFF
--- a/policy/testMapper.yaml
+++ b/policy/testMapper.yaml
@@ -195,3 +195,5 @@ datasets:
     template: deepDiff/v%(visit)d_diaSrc_f%(filter)s.fits
   deepDiff_kernelSrc:
     template: deepDiff/v%(visit)d_kernelSrc_f%(filter)s.fits
+  apPipe_metadata:
+    template: apPipe_metadata/v%(visit)d_f%(filter)s.boost


### PR DESCRIPTION
This PR registers a dataset mapping for metadata persisted by `ApPipeTask`. The config dataset is delegated to `obs_base`.