### PR TITLE
DM-13849: Convert all ap_verify test data to obs_test

### DIFF
--- a/config/ingestCalibs.py
+++ b/config/ingestCalibs.py
@@ -1,6 +1,4 @@
 # Config override for lsst.pipe.tasks.IngestCalibsTask
-from lsst.obs.test.ingestCalibs import TestCalibsParseTask
-
 config.parse.translation = {'filter': 'FILTER',
                             }
 config.parse.translators = {'calibDate': 'translate_date',


### PR DESCRIPTION
This PR fixes a bug that prevented config overrides from being used with `obs_test` calib ingestion. I'm not sure how this slipped through #46, since I called the overrides during testing.