### PR TITLE
DM-9615: Add DCR numSubfilters to set of keys to test

### DIFF
--- a/tests/test_obs_test.py
+++ b/tests/test_obs_test.py
@@ -77,7 +77,7 @@ class TestObsTest(lsst.obs.base.tests.ObsTests, lsst.utils.tests.TestCase):
 
         path_to_raw = os.path.join(data_dir, "raw", "raw_v1_fg.fits.gz")
         keys = set(('filter', 'name', 'patch', 'tract', 'visit', 'pixel_id', 'subfilter', 'description',
-                    'fgcmcycle'))
+                    'fgcmcycle', 'numSubfilters'))
         query_format = ["visit", "filter"]
         queryMetadata = (({'visit': 1}, [(1, 'g')]),
                          ({'visit': 2}, [(2, 'g')]),


### PR DESCRIPTION
Add the `numSubFilters` key to the test, that is needed for DCR coadds.