### PR TITLE
DM-6640: IsrTask is not a valid CmdLineTask

### DIFF
--- a/config/isr.py
+++ b/config/isr.py
@@ -1,2 +1,5 @@
+"""
+Test-specific overrides for IsrTask
+"""
 config.doDark = False
 config.doFringe = False

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -1,10 +1,11 @@
-"""obs_test-specific overrides for the processCcd task
+"""
+Test-specific overrides for the ProcessCcdTask
 """
 import os.path
 from lsst.utils import getPackageDir
 
-configDir = os.path.join(getPackageDir("obs_test"), "config")
-config.isr.load(os.path.join(configDir, 'isr.py'))
+obsConfigDir = os.path.join(getPackageDir("obs_test"), "config")
 
-configDir = os.path.join(getPackageDir("obs_test"), "config")
-config.calibrate.load(os.path.join(configDir, 'calibrate.py'))
+config.isr.load(os.path.join(obsConfigDir, 'isr.py'))
+
+config.calibrate.load(os.path.join(obsConfigDir, 'calibrate.py'))

--- a/config/runIsr.py
+++ b/config/runIsr.py
@@ -1,0 +1,9 @@
+"""
+Test-specific overrides for RunIsrTask
+"""
+import os.path
+from lsst.utils import getPackageDir
+
+obsConfigDir = os.path.join(getPackageDir("obs_test"), "config")
+
+config.isr.load(os.path.join(obsConfigDir, "isr.py"))


### PR DESCRIPTION
This ticket adds a stand-alone runIsr.py script, as well as ensuring that runIsr.py and processCcd.py read the same ISR configuration files.
