### PR TITLE
DM-15862: Reduce ISR code duplication between ip_isr, obs_subaru, and obs_decam

### DIFF
--- a/policy/testMapper.yaml
+++ b/policy/testMapper.yaml
@@ -207,3 +207,7 @@ datasets:
     persistable: ignored
     python: matplotlib.figure.Figure
     storage: MatplotlibStorage
+  ossThumb:
+    template: thumbs/oss_v%(visit)d_f%(filter)s.png
+  flattenedThumb:
+    template: thumbs/flattened_v%(visit)d_f%(filter)s.png


### PR DESCRIPTION

The testMapper has been updated to persist thumbnail images of the
overscan subtracted and flattened ISR images.