### PR TITLE
DM-21877: Create "marker" Butler dataset for PPDB

### DIFF
--- a/policy/testMapper.yaml
+++ b/policy/testMapper.yaml
@@ -207,6 +207,8 @@ datasets:
     template: deepDiff/v%(visit)d_kernelSrc_f%(filter)s.fits
   apPipe_metadata:
     template: apPipe_metadata/v%(visit)d_f%(filter)s.yaml
+  apdb_marker:
+    template: apdb/v%(visit)d_f%(filter)s.py
   test_plot:
     template: test_plot/v%(visit)d_f%(filter)s.png
     persistable: ignored


### PR DESCRIPTION
This PR defines the dummy location for the `apdb_marker` dataset introduced in lsst/obs_base#182.