### PR TITLE
DM-30301: Try to get log levels from log object

### DIFF
--- a/tests/test_cmdLineTask.py
+++ b/tests/test_cmdLineTask.py
@@ -27,7 +27,7 @@ import tempfile
 import lsst.utils
 import lsst.pipe.base as pipeBase
 import lsst.obs.test
-from lsst.log import Log
+import logging
 
 ObsTestDir = lsst.utils.getPackageDir("obs_test")
 DataPath = os.path.join(ObsTestDir, "data", "input")
@@ -120,14 +120,17 @@ class CmdLineTaskTestCase(unittest.TestCase):
         """
         config = ExampleTask.ConfigClass()
         config.floatField = -99.9
-        log = Log.getLogger("cmdLineTask")
+        log = logging.getLogger("cmdLineTask")
         retVal = ExampleTask.parseAndRun(
             args=[DataPath, "--output", self.outPath, "--id", "visit=2"],
             config=config,
             log=log
         )
         self.assertEqual(retVal.parsedCmd.config.floatField, -99.9)
-        self.assertIs(retVal.parsedCmd.log, log)
+
+        # The logger class may have been changed but the logger name
+        # should still match.
+        self.assertEqual(retVal.parsedCmd.log.name, log.name)
 
     def testDoReturnResults(self):
         """Test the doReturnResults flag


### PR DESCRIPTION
Do not assume lsst.log is involved. Using getLogger() from
pipe_base does imply that python logging is used and at some
point this test should be converted over explicitly to use
logging.

Requires lsst/pipe_base#191